### PR TITLE
Fix iOS

### DIFF
--- a/RNHttpServer.podspec
+++ b/RNHttpServer.podspec
@@ -12,13 +12,12 @@ Pod::Spec.new do |s|
   s.author             = { "author" => "hi@nmartinez.dev" }
   s.platform     = :ios, "7.0"
   s.source       = { :git => "https://github.com/nmartinezb3/react-native-http-server.git", :tag => "master" }
-  s.source_files  = "RNHttpServer/**/*.{h,m}"
+  s.source_files  = "ios/**/*.{h,m,swift}"
   s.requires_arc = true
 
 
   s.dependency "React"
   #s.dependency "others"
-
+  s.dependency "GCDWebServer", "~> 3.5.3"
 end
 
-  

--- a/httpServer.js
+++ b/httpServer.js
@@ -64,10 +64,9 @@ export class HTTPServer {
       WebServerManager.subscribe(eventName);
       this.subscription = this.eventEmitter.addListener(
         eventName,
-        requestId => {
-          const {data, status} = handler('', data);
-          console.log(requestId);
-          WebServerManager.response(requestId, status, JSON.stringify(data));
+        ({requestId, body}) => {
+          const {data, status} = handler(body);
+          WebServerManager.response(requestId, status, data);
         },
       );
     });

--- a/httpServer.js
+++ b/httpServer.js
@@ -51,7 +51,7 @@ export class HTTPServer {
   }
 
   start() {
-    return WebServerManager.startServer();
+    return WebServerManager.startServer(this.port);
   }
 
   stop() {

--- a/ios/RNHTTPServer.swift
+++ b/ios/RNHTTPServer.swift
@@ -64,12 +64,12 @@ class WebServerManager: RCTEventEmitter {
    Start `webserver` on the Main Thread
   - Returns:`Promise` to JS side, resolve the server URL and reject thrown errors
    */
-  @objc public func startServer(_ resolve: RCTPromiseResolveBlock, rejecter reject: RCTPromiseRejectBlock) -> Void {
+  @objc public func startServer(_ port: NSInteger, resolver resolve: RCTPromiseResolveBlock, rejecter reject: RCTPromiseRejectBlock) -> Void {
      if (serverRunning == ServerState.Stopped){
-       DispatchQueue.main.sync{
+       DispatchQueue.main.sync {
            serverRunning = ServerState.Running
-           webServer.start(withPort: 8080, bonjourName: "React Native Web Server")
-           resolve(webServer.serverURL?.absoluteString )
+           webServer.start(withPort: UInt(port), bonjourName: "React Native Web Server")
+           resolve(webServer.serverURL?.absoluteString)
        }
      } else {
        let errorMessage : String = "Server start failed"

--- a/ios/RNHTTPServer.swift
+++ b/ios/RNHTTPServer.swift
@@ -24,9 +24,9 @@ class WebServerManager: RCTEventEmitter {
     super.init()
   }
 
-//  @objc static override func requiresMainQueueSetup() -> Bool {
-//    return true
-//  }
+  @objc static override func requiresMainQueueSetup() -> Bool {
+    return true
+  }
   
   override func supportedEvents() -> [String]! {
     return ["GET", "POST", "PUT", "PATCH", "DELETE"]
@@ -53,10 +53,15 @@ class WebServerManager: RCTEventEmitter {
   
  
   @objc public func subscribe(_ method: String) {
-    webServer.addDefaultHandler(forMethod: method, request: GCDWebServerRequest.self) { (request, completionBlock) in
+    webServer.addDefaultHandler(forMethod: method, request: GCDWebServerDataRequest.self) { (request, completionBlock) in
       let requestId = NSString(string: UUID().uuidString)
+      let requestBodyData = (request as! GCDWebServerDataRequest).data;
+      let requestBodyString = NSString(data: requestBodyData, encoding: String.Encoding.utf8.rawValue);
       self.completionBlocks.setObject(completionBlock, forKey: requestId)
-      self.sendEvent(withName: method, body: requestId)
+      self.sendEvent(withName: method, body: [
+        "requestId": requestId,
+        "body": requestBodyString,
+      ])
     }
   }
   

--- a/ios/RNHttpServer.m
+++ b/ios/RNHttpServer.m
@@ -9,7 +9,8 @@
 
 @interface RCT_EXTERN_MODULE(WebServerManager, NSObject)
 RCT_EXTERN_METHOD(initWebServer)
-RCT_EXTERN_METHOD(startServer: (RCTPromiseResolveBlock) resolve
+RCT_EXTERN_METHOD(startServer: (NSInteger *) port
+                  resolver: (RCTPromiseResolveBlock) resolve
                   rejecter: (RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(createServer: (RCTPromiseResolveBlock) resolve
                   rejecter: (RCTPromiseRejectBlock)reject)


### PR DESCRIPTION
Hi, I hope this PR will help iOS developers to better harness this package.

The module was not usable for iOS for two reasons:
1. .podspec is not correctly configured
2. dependency GCDWebServer is not added

Plus, iOS server does not respect argument 'port' because the port actually used is hard-coded.

I am new to Swift/Objective-C, so if there are any mistakes I hope you can help me correct them